### PR TITLE
Fix resource unavailable bug

### DIFF
--- a/nengo_gui/server.py
+++ b/nengo_gui/server.py
@@ -585,6 +585,7 @@ class WebSocket(object):
 def _sendall(socket, data):
     bytes_sent = 0
     while bytes_sent < len(data):
+        select.select((), (socket,), ())  # ensure socket is not full
         bytes_sent += socket.send(data[bytes_sent:])
 
 


### PR DESCRIPTION
At the moment, we don't handle a full socket gracefully.  This mostly comes up if you have a large complex htmlview, which ends up breaking horribly once everything fills up.

I still need to put together a nice test, but here's a fix (this was reported in #813 )
