### PR TITLE
Always pan view when dragging with CTRL or MMB pressed

### DIFF
--- a/nengo_gui/static/components/component.js
+++ b/nengo_gui/static/components/component.js
@@ -73,6 +73,10 @@ Nengo.Component = function(parent, args) {
                 self.menu.hide_any();
             },
             onmove: function (event) {
+                if (Nengo.netgraph.capture_move_event(event)) {
+                    return;
+                }
+
                 var target = event.target;
 
                 self.x = self.x + event.dx / (self.viewport.w * self.viewport.scale);

--- a/nengo_gui/static/components/netgraph.js
+++ b/nengo_gui/static/components/netgraph.js
@@ -683,3 +683,19 @@ Nengo.NetGraph.prototype.scaleMiniMapViewBox = function () {
     this.view.setAttribute('width', w / this.scale);
     this.view.setAttribute('height', h / this.scale);
 }
+
+/** Called from the individual component ondragmove handlers in order to pan
+ * the entire view whenever CTRL or the middle mouse button are pressed.
+ * Returns true if the event has been processed by the NetGraph component and
+ * no further event processing must be performed by the calling code.
+ * Returns false otherwise. */
+Nengo.NetGraph.prototype.capture_move_event = function (event) {
+    // For more constants see https://www.w3.org/TR/uievents/#mouseevent
+    var MOUSE_BUTTON_MIDDLE_MASK = 4
+
+    if (event.ctrlKey || (event.buttons & MOUSE_BUTTON_MIDDLE_MASK)) {
+        interact(this.svg).ondragmove(event);
+        return true;
+    }
+    return false;
+}

--- a/nengo_gui/static/components/netgraph_item.js
+++ b/nengo_gui/static/components/netgraph_item.js
@@ -177,6 +177,10 @@ Nengo.NetGraphItem = function(ng, info, minimap, mini_item) {
                     self.move_to_front();
                 },
                 onmove: function(event) {
+                    if (Nengo.netgraph.capture_move_event(event)) {
+                        return;
+                    }
+
                     var w = self.ng.get_scaled_width();
                     var h = self.ng.get_scaled_height();
                     var item = self.ng.svg_objects[uid];


### PR DESCRIPTION
Always pan the entire view when dragging the mouse while holding the control key or whenever the middle mouse button is pressed.

**Rationale:**
When zoomed into several layers of nested networks, it is currently impossible to navigate the visualization without zooming out and then zooming in again at another point, since dragging moves the component/subnetwork the mouse is over, and not the viewport.

Other applications solve this by panning the view if a modifier key is pressed. For example, in Inkscape this is solved by letting users pan the view when the middle mouse button (MMB) is pressed. In Blender (a prime example for usability), one can pan the view when pressing CTRL. I propose allowing both, since Apple stuff does not feature a middle mouse button to my knowledge.

**Issues with this PR:**
The entire patch is rather hackish. It actually intercepts the ondragmove event of the components and redirects the event to the Netgraph component if either CTRL or MMB are pressed (``event.button`` is useless in the MouseMoveEvent.) Furthermore, a small patch to intercept.js is required. We may have to file an upstream bug report.

**Todo:**
- [x] Test with Firefox
- [x] Test with Chromium
- [ ] Test with Edge
- [ ] Test with Safari