### PR TITLE
Basic support for nengo_spa.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Release History
 0.3.2 (unreleased)
 ==================
 
+- Support for nengo_spa
 - Added --browser option
 - Added --unsecure option
 - Fixed backspace not working on sliders, search box

--- a/nengo_gui/components/pointer.py
+++ b/nengo_gui/components/pointer.py
@@ -2,7 +2,8 @@ import copy
 import itertools
 
 import nengo
-import nengo.spa as spa
+import nengo_spa as spa
+from nengo_spa.examine import pairs
 import numpy as np
 
 from nengo_gui.components.component import Component
@@ -30,7 +31,7 @@ class Pointer(SpaPlot):
         # Looping-in has the advantage of actually changing the
         # neural activity of the population, rather than just changing
         # the output.
-        self.loop_in_whitelist = [spa.Buffer, spa.Memory, spa.State]
+        self.loop_in_whitelist = [spa.State]
 
         self.node = None
         self.conn1 = None
@@ -60,13 +61,13 @@ class Pointer(SpaPlot):
         key_similarities = np.dot(vocab.vectors, x)
         over_threshold = key_similarities > 0.01
         matches = zip(key_similarities[over_threshold],
-                      np.array(vocab.keys)[over_threshold])
+                      [k for i, k in enumerate(vocab) if over_threshold[i]])
         if self.config.show_pairs:
             self.vocab_out.include_pairs = True
-            pair_similarities = np.dot(vocab.vector_pairs, x)
+            pair_similarities = np.array([np.dot(vocab.parse(p).v, x) for p in pairs(vocab)])
             over_threshold = pair_similarities > 0.01
             pair_matches = zip(pair_similarities[over_threshold],
-                               np.array(vocab.key_pairs)[over_threshold])
+                    (k for i, k in enumerate(pairs(vocab)) if over_threshold[i]))
             matches = itertools.chain(matches, pair_matches)
 
         text = ';'.join(['%0.2f%s' % ( min(sim, 9.99), key) for sim, key in matches])

--- a/nengo_gui/components/pointer.py
+++ b/nengo_gui/components/pointer.py
@@ -45,7 +45,10 @@ class Pointer(SpaPlot):
 
     def add_nengo_objects(self, page):
         with page.model:
-            output = self.obj.outputs[self.target][0]
+            if self.target.startswith('<'):
+                output = getattr(self.obj, self.target[1:-1])
+            else:
+                output = self.obj.outputs[self.target][0]
             self.node = nengo.Node(self.gather_data,
                                    size_in=self.vocab_out.dimensions,
                                    size_out=self.vocab_out.dimensions)

--- a/nengo_gui/components/spa_plot.py
+++ b/nengo_gui/components/spa_plot.py
@@ -1,6 +1,6 @@
 import collections
 
-from nengo.spa.module import Module
+import nengo_spa as spa
 
 from nengo_gui.components.component import Component
 
@@ -31,7 +31,7 @@ class SpaPlot(Component):
     @staticmethod
     def applicable_targets(obj):
         targets = []
-        if isinstance(obj, Module):
+        if isinstance(obj, spa.Network):
             for target_name, (obj, vocab) in obj.outputs.items():
                 if vocab is not None:
                     targets.append(target_name)

--- a/nengo_gui/components/spa_plot.py
+++ b/nengo_gui/components/spa_plot.py
@@ -1,6 +1,10 @@
 import collections
 
-import nengo_spa as spa
+import nengo.spa as spa
+try:
+    import nengo_spa
+except ImportError:
+    nengo_spa = None
 
 from nengo_gui.components.component import Component
 
@@ -31,8 +35,9 @@ class SpaPlot(Component):
     @staticmethod
     def applicable_targets(obj):
         targets = []
-        if isinstance(obj, spa.Network):
-            for target_name, (obj, vocab) in obj.outputs.items():
-                if vocab is not None:
-                    targets.append(target_name)
+        if (isinstance(obj, spa.module.Module) or
+            (nengo_spa is not None and isinstance(obj, nengo_spa.Network))):
+                for target_name, (obj, vocab) in obj.outputs.items():
+                    if vocab is not None:
+                        targets.append(target_name)
         return targets

--- a/nengo_gui/components/spa_similarity.py
+++ b/nengo_gui/components/spa_similarity.py
@@ -36,7 +36,10 @@ class SpaSimilarity(SpaPlot):
 
     def add_nengo_objects(self, page):
         with page.model:
-            output = self.obj.outputs[self.target][0]
+            if self.target.startswith('<'):
+                output = getattr(self.obj, self.target[1:-1])
+            else:
+                output = self.obj.outputs[self.target][0]
             self.node = nengo.Node(self.gather_data,
                                    size_in=self.vocab_out.dimensions)
             self.conn = nengo.Connection(output, self.node, synapse=0.01)


### PR DESCRIPTION
This adds basic support for `nengo_spa`, but breaks support for `nengo.spa` (note the dot instead of underscore). There might still be things that do not work properly and before a merge the complete SPA related code needs to be gone through and checked.

I think there are slightly to many differences to conveniently support both SPA versions. With some refactoring this might be more realistic, but that also requires more effort and it migth be better to wait for the refactored frontend #806.

Ultimately, I expect these classes to move to `nengo_spa`, but this requires the plugin structure to be in place which I probably won't tackle before the frontend refactoring is done either.