### PR TITLE
Allow configure dialog to open without editor.

### DIFF
--- a/nengo_gui/static/modal.css
+++ b/nengo_gui/static/modal.css
@@ -136,3 +136,7 @@ div.modal {
 .modal-dialog.modal-sm td {
     padding: 4px;
 }
+
+#myModalForm .disabled {
+    color: darkgrey;
+}

--- a/nengo_gui/static/modal.js
+++ b/nengo_gui/static/modal.js
@@ -308,16 +308,18 @@ Nengo.Modal.prototype.main_config = function() {
         Nengo.netgraph.transparent_nets = $('#transparent-nets').prop('checked');
     });
 
-    $('#sync-editor').prop('checked', Nengo.ace.auto_update);
-    $('#sync-editor').change(function () {
-        Nengo.ace.auto_update = $('#sync-editor').prop('checked');
-        Nengo.ace.update_trigger = $('#sync-editor').prop('checked');
-    });
-    $('#autocomplete').prop('checked', Nengo.config.autocomplete);
-    $('#autocomplete').change(function () {
-        Nengo.ace.editor.setOption("enableLiveAutocompletion", $('#autocomplete').prop('checked'));
-	Nengo.config.autocomplete = $('#autocomplete').prop('checked');
-    });
+    if (typeof Nengo.ace != 'undefined') {
+        $('#sync-editor').prop('checked', Nengo.ace.auto_update);
+        $('#sync-editor').change(function () {
+            Nengo.ace.auto_update = $('#sync-editor').prop('checked');
+            Nengo.ace.update_trigger = $('#sync-editor').prop('checked');
+        });
+        $('#autocomplete').prop('checked', Nengo.config.autocomplete);
+        $('#autocomplete').change(function () {
+            Nengo.ace.editor.setOption("enableLiveAutocompletion", $('#autocomplete').prop('checked'));
+            Nengo.config.autocomplete = $('#autocomplete').prop('checked');
+        });
+    }
 
     $('#config-fontsize').val(Nengo.netgraph.font_size);
     $('#config-fontsize').bind('keyup input', function () {

--- a/nengo_gui/static/modal.js
+++ b/nengo_gui/static/modal.js
@@ -319,6 +319,11 @@ Nengo.Modal.prototype.main_config = function() {
             Nengo.ace.editor.setOption("enableLiveAutocompletion", $('#autocomplete').prop('checked'));
             Nengo.config.autocomplete = $('#autocomplete').prop('checked');
         });
+    } else {
+	$('#sync-editor').attr("disabled", "disabled");
+	$('#autocomplete').attr("disabled", "disabled");
+	$('#sync-editor').parent().addClass("disabled");
+	$('#autocomplete').parent().addClass("disabled");
     }
 
     $('#config-fontsize').val(Nengo.netgraph.font_size);

--- a/nengo_gui/static/top_toolbar.js
+++ b/nengo_gui/static/top_toolbar.js
@@ -83,7 +83,7 @@ Nengo.Toolbar.prototype.config_modal_show = function() {
     var original = {zoom: Nengo.netgraph.zoom_fonts,
                     font_size: Nengo.netgraph.font_size,
                     aspect_resize: Nengo.netgraph.aspect_resize,
-                    auto_update: Nengo.ace.auto_update,
+                    auto_update: (typeof Nengo.ace != 'undefined') ? Nengo.ace.auto_update : false,
                     transparent_nets: Nengo.netgraph.transparent_nets,
                     scriptdir: Nengo.config.scriptdir};
 
@@ -106,7 +106,9 @@ Nengo.Toolbar.prototype.config_modal_show = function() {
             Nengo.netgraph.font_size = original["font_size"];
             Nengo.netgraph.transparent_nets = original["transparent_nets"];
             Nengo.netgraph.aspect_resize = original["aspect_resize"];
-            Nengo.ace.auto_update = original["auto_update"];
+            if (typeof Nengo.ace != 'undefined') {
+                Nengo.ace.auto_update = original["auto_update"];
+            }
             Nengo.config.scriptdir = original["scriptdir"];
             $('#cancel-button').attr('data-dismiss', 'modal');
     });


### PR DESCRIPTION
Addresses #910.

The solution is a bit of a hack. The offending checkbox should probably
be completely removed or disabled if there is no editor (at the moment
it can be toggled, but won't have any effect). Also the if-statements
introduced in this commit are a bit of a hack. There is probably some
better way to address this without the repeated checking whether
Nengo.ace is defined. However, it might make sense to wait for the
completion of the frontend refactoring before addressing this.