### PR TITLE
Add nengo_mpi and nengo_dl as backend options in gui

### DIFF
--- a/nengo_gui/exec_env.py
+++ b/nengo_gui/exec_env.py
@@ -9,6 +9,7 @@ from nengo.utils.compat import StringIO
 
 # list of Simulators to check for
 known_modules = ['nengo', 'nengo_ocl', 'nengo_distilled',
+                 'nengo_dl', 'nengo_mpi',
                  'nengo_brainstorm', 'nengo_spinnaker']
 
 


### PR DESCRIPTION
Adding nengo_mpi and nengo_dl as possible backends to be looked for in nengo_gui/exec_env.py

