### PR TITLE
Do not allow access to resources outside of static.

### DIFF
--- a/nengo_gui/guibackend.py
+++ b/nengo_gui/guibackend.py
@@ -150,7 +150,11 @@ class GuiRequestHandler(server.HttpWsRequestHandler):
     @RequireAuthentication('/login')
     def serve_static(self):
         """Handles http://host:port/static/* by returning pkg data"""
-        fn = os.path.join('static', self.resource)
+        assert self.resource[0] == '/'
+        static_dir = 'static' + os.sep
+        fn = os.path.normpath(self.resource[1:])
+        if os.path.commonprefix((static_dir, fn)) != static_dir:
+            raise server.Forbidden()
         mimetype, encoding = mimetypes.guess_type(fn)
         data = pkgutil.get_data('nengo_gui', fn)
         return server.HttpResponse(data, mimetype)


### PR DESCRIPTION
This is another security issue. By providing paths like `/static/../__init__.py` it was possible to access arbitrary files on the file system. In `master` this requires at least authentication, but in #921 I'm removing the constraint because the favicon should be available without login and we might want to use some of the style sheets on the login page at some point.