### PR TITLE
Control which browser is used

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Release History
 0.3.2 (unreleased)
 ==================
 
+- Added --browser option
 - Added --unsecure option
 - Fixed backspace not working on sliders, search box
 - Added autocomplete to text editor

--- a/nengo_gui/main.py
+++ b/nengo_gui/main.py
@@ -18,6 +18,13 @@ def old_main():
 
 
 def main():
+    try:
+        browser_help = ('browser to use (options: "%s")' % 
+                        '", "'.join(webbrowser._tryorder))
+    except (AttributeError, TypeError):
+        # just in case the undocumented webbrowser._tryorder changes
+        browser_help='browser to use (e.g. chrome, firefox)'
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '-p', '--password', dest='password', metavar='PASS',
@@ -46,7 +53,7 @@ def main():
         default='nengo', type=str, help='default backend to use')
     parser.add_argument('--browser', dest='browser', type=str,
         metavar='BROWSER', default=True,
-        help='browser to use (e.g. chrome, firefox)')
+        help=browser_help)
     parser.add_argument('--no-browser', dest='browser', action='store_false')
     parser.add_argument(
         '--auto-shutdown', nargs=1, type=float,
@@ -115,7 +122,17 @@ def main():
             if args.browser is True:
                 wb = webbrowser.get()
             else:
-                wb = webbrowser.get(args.browser)
+                try:
+                    wb = webbrowser.get(args.browser)
+                except webbrowser.Error:
+                    try:
+                        print('Known browsers: \n  %s' % 
+                              '\n  '.join(webbrowser._tryorder))
+                    except (AttributeError, TypeError):
+                        # just in case the undocumented webbrowser._tryorder
+                        #  changes
+                        print('Could not determine the list of known browsers.')
+                    raise
             t = threading.Thread(
                 target=wb.open,
                 args=('%s//%s:%d/?token=%s' % (

--- a/nengo_gui/main.py
+++ b/nengo_gui/main.py
@@ -44,7 +44,9 @@ def main():
     parser.add_argument(
         '-b', '--backend', metavar='BACKEND',
         default='nengo', type=str, help='default backend to use')
-    parser.add_argument('--browser', dest='browser', action='store_true')
+    parser.add_argument('--browser', dest='browser', type=str,
+        metavar='BROWSER', default=True,
+        help='browser to use (e.g. chrome, firefox)')
     parser.add_argument('--no-browser', dest='browser', action='store_false')
     parser.add_argument(
         '--auto-shutdown', nargs=1, type=float,
@@ -110,8 +112,12 @@ def main():
             protocol = 'https:' if server_settings.use_ssl else 'http:'
             host = 'localhost'
             port = s.server.server_port
+            if args.browser is True:
+                wb = webbrowser.get()
+            else:
+                wb = webbrowser.get(args.browser)
             t = threading.Thread(
-                target=webbrowser.open,
+                target=wb.open,
                 args=('%s//%s:%d/?token=%s' % (
                     protocol, host, port, s.server.gen_one_time_token()),))
             t.start()


### PR DESCRIPTION
Here's an attempt at #203.  It should let you select a browser when starting nengo, so you can do something like  `nengo --browser firefox`.  It uses whatever browsers are registered with python (see https://docs.python.org/2/library/webbrowser.html for a list).

However, it doesn't seem to work on Windows for anything other than `windows-default`, and I haven't seen a good way to figure out what browsers are available (to give a useful error message).  But, I figured I would post the PR and see if it works for other people.