### PR TITLE
Added --unsecure option for bypassing ssl

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Release History
 0.3.2 (unreleased)
 ==================
 
+- Added --unsecure option
 - Fixed backspace not working on sliders, search box
 - Added autocomplete to text editor
 - Added visual depiction of modulatory and inhibitory connections

--- a/nengo_gui/guibackend.py
+++ b/nengo_gui/guibackend.py
@@ -13,7 +13,10 @@ try:
     from urllib.parse import unquote
 except ImportError:  # Python 2.7
     from urllib import unquote
-import ssl
+try:
+    import ssl
+except ImportError:  # for Python without ssl support
+    from . import nossl as ssl
 import time
 
 import nengo_gui

--- a/nengo_gui/main.py
+++ b/nengo_gui/main.py
@@ -33,6 +33,8 @@ def main():
     parser.add_argument(
         '--key', nargs=1, default=[None], type=str, help="SSL key file")
     parser.add_argument(
+        '--unsecure', action='store_true', help='do not use SSL security')
+    parser.add_argument(
         '-P', '--port', dest='port', metavar='PORT',
         type=int, help='port to run server on')
     parser.add_argument(
@@ -75,7 +77,8 @@ def main():
     server_settings = GuiServerSettings(
         (host, port), args.auto_shutdown[0], password_hash=password_hash,
         ssl_cert=args.cert[0], ssl_key=args.key[0])
-    if host != 'localhost' and not server_settings.use_ssl:
+    if (host != 'localhost' and not server_settings.use_ssl and
+            not args.unsecure):
         raise ValueError(
             "Listening on external network interfaces only allowed with SSL.")
 

--- a/nengo_gui/nossl.py
+++ b/nengo_gui/nossl.py
@@ -1,0 +1,6 @@
+class SSLError(Exception):
+    pass
+
+
+def wrap_socket(socket, certfile, keyfile, server_side):
+    raise SSLError('Could not import ssl')

--- a/nengo_gui/server.py
+++ b/nengo_gui/server.py
@@ -8,7 +8,10 @@ import json
 import select
 import socket
 import struct
-import ssl
+try:
+    import ssl
+except ImportError:  # for Python without ssl support
+    from . import nossl as ssl
 import sys
 import threading
 import traceback


### PR DESCRIPTION
Some versions of Python do not support ssl (c.f. https://techglimpse.com/install-python-openssl-support-tutorial/ ).  Currently, those versions of Python cannot run nengo_gui.  Furthermore, sometimes we may want to run nengo_gui remotely without ssl (for example, if we want to run nengo_gui on an embedded device that does not have ssl or a screen).  

This PR does two things.  First, it adds a fallback for when `import ssl` fails.  Second, it adds an `--unsecure` option which lets people explicitly turn ssl security off.