### PR TITLE
Adding event hooks for the GUI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Release History
 0.4.4 (unreleased)
 ==================
 
+- Improvement (Experimental): Added simulator hooks
 - Improvement: Added audible spike sounds
 - Improvement (Experimental): Nodes have access to the GUI keyboard state
 - Improvement: support for nengo-bio Connections

--- a/nengo_gui/components/sim_control.py
+++ b/nengo_gui/components/sim_control.py
@@ -190,11 +190,16 @@ class SimControl(Component):
     def message(self, msg):
         if msg == 'pause':
             self.paused = True
+            if 'on_pause' in self.page.locals:
+                self.page.locals['on_pause'](self.page.sim)
         elif msg == 'config':
             self.send_config_options = True
         elif msg == 'continue':
             if self.page.sim is None:
                 self.page.rebuild = True
+            else:
+                if 'on_continue' in self.page.locals:
+                    self.page.locals['on_continue'](self.page.sim)
             self.paused = False
         elif msg == 'reset':
             self.paused = True

--- a/nengo_gui/guibackend.py
+++ b/nengo_gui/guibackend.py
@@ -460,6 +460,7 @@ class GuiServer(server.ManagedThreadHttpServer):
 
     def remove_page(self, page):
         self._last_access = time.time()
+        page.close()
         self.pages.remove(page)
         if (not self._shutting_down and self.settings.auto_shutdown > 0 and
                 len(self.pages) <= 0):


### PR DESCRIPTION
The idea here is to allow people to write functions that will automatically get called by nengo_gui at various different times.  In particular, nengo_gui will look for functions with the following names:

 - `def on_step(sim)`: called every simulation time step
 - `def on_start(sim)`: called just before the first time step, after the user presses the Play button
 - `def on_pause(sim)`: called when the pause button is pressed
 - `def on_continue(sim)`: called when the Play button is pressed after a pause
 - `def on_close(sim)`: called when the page is closed

In each case, the active Simulator object is passed in as the only argument.

There are two main use cases where I've found this handy.  First, if the Nengo model is controlling a robot, it is *extremely* useful to be able to send a `motors.stop()` command when you pause the simulation.  I've also used the `on_start` and `on_close` functions to initiate and shut down communication between the nengo model and a robot.

Second, the `on_step(sim)` is needed if I want to update a display with information I can only get from the Simulator.  For example, my https://github.com/tcstewar/nengo_learning_display repository uses this to make graphs of the functions being learned by nengo learning rules, and the graphs update as the learning rule adjusts the weights.

So, I definitely think hooks like this are useful for nengo.  I also like the simplicity of this implementation.  However, I could see other syntax being suggested (or other ways of marking functions to indicate that they should be used as hooks like this).

