### PR TITLE
Implement hooks with register functions/decorators

### DIFF
--- a/nengo_gui/components/sim_control.py
+++ b/nengo_gui/components/sim_control.py
@@ -8,6 +8,7 @@ import json
 
 from nengo_gui.components.component import Component
 import nengo_gui.exec_env
+from nengo_gui import hooks
 from nengo_gui.server import WebSocketFrame
 
 
@@ -190,11 +191,15 @@ class SimControl(Component):
     def message(self, msg):
         if msg == 'pause':
             self.paused = True
+            hooks.on_pause.execute(self.page)
         elif msg == 'config':
             self.send_config_options = True
         elif msg == 'continue':
             if self.page.sim is None:
                 self.page.rebuild = True
+                hooks.on_start.execute(self.page)
+            else:
+                hooks.on_continue.execute(self.page)
             self.paused = False
         elif msg == 'reset':
             self.paused = True

--- a/nengo_gui/guibackend.py
+++ b/nengo_gui/guibackend.py
@@ -432,6 +432,7 @@ class GuiServer(server.ManagedThreadHttpServer):
 
     def remove_page(self, page):
         self._last_access = time.time()
+        page.close()
         self.pages.remove(page)
         if (not self._shutting_down and self.settings.auto_shutdown > 0 and
                 len(self.pages) <= 0):

--- a/nengo_gui/hooks.py
+++ b/nengo_gui/hooks.py
@@ -1,0 +1,40 @@
+from collections import defaultdict
+
+
+class Context(object):
+    context_stack = [None]
+
+    def __init__(self, page):
+        self.page = page
+
+    def __enter__(self):
+        self.context_stack.append(self.page)
+        for hook in (on_step, on_start, on_pause, on_continue, on_close):
+            # NOTE entering context clears hooks, this might be surprising and
+            # there might be a better solution to prevent accumulation of hooks
+            # from multiple code executions.
+            if self.page in hook.callbacks:
+                del hook.callbacks[self.page]
+        return self
+
+    def __exit__(self, exc_type, exc_value, tb):
+        assert self.context_stack.pop() is self.page
+
+
+class Hook(object):
+    def __init__(self):
+        self.callbacks = defaultdict(list)  # FIXME page references should be weak
+
+    def __call__(self, fn):
+        self.callbacks[Context.context_stack[-1]].append(fn)
+
+    def execute(self, page):
+        for cb in self.callbacks[page] + self.callbacks[None]:
+            cb(page.sim)
+
+
+on_step = Hook()
+on_start = Hook()
+on_pause = Hook()
+on_continue = Hook()
+on_close = Hook()


### PR DESCRIPTION
This is a proof-of-concept of implementing the hooks proposed in #953 with decorators to explicitely register the hooks. This would still need some work before it is ready to merge:
* [ ] tests?
* [ ] use weak references to pages
* [ ] tweaks to the API?
* ...?

Hooks will be registered on a per page basis which should alleviate the main concern about this approach. In addition global hooks can be registered which allows to register hooks for IPythonViz (to be renamed to InlineGUI).