### PR TITLE
Ipythonviz fixes

### DIFF
--- a/nengo_gui/config.py
+++ b/nengo_gui/config.py
@@ -58,6 +58,9 @@ class Config(nengo.Config):
                     lines.append('_viz_config[%s].has_layout=%s'
                                  % (uid, self[obj].has_layout))
 
+            elif isinstance(obj, nengo_gui.components.editor.Editor):
+                pass  # Do not persist editor
+
             elif isinstance(obj, nengo_gui.components.component.Component):
                 lines.append('%s = %s' % (uid, obj.code_python(uids)))
                 for k in obj.config_defaults.keys():

--- a/nengo_gui/ipython.py
+++ b/nengo_gui/ipython.py
@@ -41,7 +41,7 @@ class IPythonViz(object):
         self.port = server.server.server_port
 
         self.url = self.get_url(
-            self.host, self.port, token=server.server.settings.auth_token)
+            self.host, self.port, token=server.server.auth_token)
 
     @staticmethod
     def get_url(host, port, action=None, token=None):

--- a/nengo_gui/ipython.py
+++ b/nengo_gui/ipython.py
@@ -72,7 +72,7 @@ class IPythonViz(object):
         server_settings = nengo_gui.guibackend.GuiServerSettings(
             ('localhost', 0))
         model_context = nengo_gui.guibackend.ModelContext(
-            model=model, locals=get_ipython().user_ns, filename=name,
+            model=model, locals=get_ipython().user_ns, filename=None,
             writeable=False)
         page_settings = nengo_gui.page.PageSettings(
             filename_cfg=cfg,

--- a/nengo_gui/page.py
+++ b/nengo_gui/page.py
@@ -276,11 +276,12 @@ class Page(object):
         if '_viz_net_graph' not in self.locals:
             c = nengo_gui.components.NetGraph()
             self.locals['_viz_net_graph'] = c
-        # FIXME general editor
-        if '_viz_ace_editor' not in self.locals:
-            c = self.settings.editor_class()
-            # c = nengo_gui.components.AceEditor()
-            self.locals['_viz_ace_editor'] = c
+
+        # Scrap legacy editor in config
+        if '_viz_ace_editor' in self.locals:
+            del self.locals['_viz_ace_editor']
+        # Always use the editor given in page settings, do not rely on config
+        self.locals['_viz_editor'] = self.settings.editor_class()
 
         if self.model is not None:
             if config[self.model].pos is None:


### PR DESCRIPTION
Fixes the access to the authentication token that has changed and fixes #846 by not using the editor saved in the config (and no longer saving the editor to the config at all). Instead the editor from the page settings will always be used.

Relying on the config can cause problems. For instance, when the config was writting by the standard GUI with ACE editor, it will load the ACE editor also when reusing that config within IPythonViz. But the editor needs to be deactivated in IPythonViz to have it work properly (the editor sends empty code that gets compiled and is then used instead of the actual model passed to IPythonViz).
