### PR TITLE
Added hooks registered per model

### DIFF
--- a/nengo_gui/__init__.py
+++ b/nengo_gui/__init__.py
@@ -3,3 +3,4 @@ from .viz import Viz   # deprecated
 from .version import version as __version__
 from .namefinder import NameFinder
 from .main import main, old_main
+from . import hooks

--- a/nengo_gui/components/sim_control.py
+++ b/nengo_gui/components/sim_control.py
@@ -9,6 +9,7 @@ import json
 from nengo_gui.components.component import Component
 import nengo_gui.exec_env
 from nengo_gui.server import WebSocketFrame
+import nengo_gui.hooks
 
 
 class SimControl(Component):
@@ -190,11 +191,18 @@ class SimControl(Component):
     def message(self, msg):
         if msg == 'pause':
             self.paused = True
+            nengo_gui.hooks.on_pause.trigger(self.page.model,
+                                             self.page.sim)
         elif msg == 'config':
             self.send_config_options = True
         elif msg == 'continue':
             if self.page.sim is None:
                 self.page.rebuild = True
+                nengo_gui.hooks.on_start.trigger(self.page.model,
+                                                 self.page.sim)
+            else:
+                nengo_gui.hooks.on_continue.trigger(self.page.model,
+                                                    self.page.sim)
             self.paused = False
         elif msg == 'reset':
             self.paused = True

--- a/nengo_gui/guibackend.py
+++ b/nengo_gui/guibackend.py
@@ -432,6 +432,7 @@ class GuiServer(server.ManagedThreadHttpServer):
 
     def remove_page(self, page):
         self._last_access = time.time()
+        page.close()
         self.pages.remove(page)
         if (not self._shutting_down and self.settings.auto_shutdown > 0 and
                 len(self.pages) <= 0):

--- a/nengo_gui/hooks.py
+++ b/nengo_gui/hooks.py
@@ -1,0 +1,22 @@
+import weakref
+
+class Hook(object):
+    def __init__(self):
+        self.callbacks = weakref.WeakKeyDictionary()
+    def trigger(self, model, sim):
+        items = self.callbacks.get(model, [])
+        for callback in items:
+            callback(sim)
+    def __call__(self, model):
+        def register(fn, model=model, callbacks=self.callbacks):
+            if model not in callbacks:
+                callbacks[model] = [fn]
+            else:
+                callbacks[model].append(fn)
+        return register
+
+on_step = Hook()
+on_start = Hook()
+on_pause = Hook()
+on_continue = Hook()
+on_close = Hook()

--- a/nengo_gui/page.py
+++ b/nengo_gui/page.py
@@ -13,6 +13,7 @@ import nengo
 import nengo_gui
 import nengo_gui.user_action
 import nengo_gui.config
+import nengo_gui.hooks
 import nengo_gui.seed_generation
 
 
@@ -513,6 +514,7 @@ class Page(object):
                         self.sim.run_steps(self.sim.max_steps)
                     else:
                         self.sim.step()
+                        nengo_gui.hooks.on_step.trigger(self.model, self.sim)
                 except Exception as err:
                     if self.finished:
                         return
@@ -520,8 +522,13 @@ class Page(object):
                     self.error = dict(trace=traceback.format_exc(), line=line)
                     self.sim = None
             while self.sims_to_close:
+                nengo_gui.hooks.on_close.trigger(self.model, self.sim)
                 self.sims_to_close.pop().close()
 
             if self.rebuild:
                 self.build()
         self.sim = None
+
+    def close(self):
+        if self.sim is not None:
+            nengo_gui.hooks.on_close.trigger(self.model, self.sim)


### PR DESCRIPTION
This is another implementation of hooks (see #957 and #953 for the previous attempts).  

In #953 , the hooks were implemented by just having magic variables `on_step`, `on_pause`, etc, and if you happened to define these, then the GUI would call them.  However, this is a) rather magical, and b) rather non-discoverable, and c) rather annoying to debug if you're using a branch that doesn't support them.

So, @jgosmann implemented a decorator-based approach.  It interacted with the ExecutionEnvironment system in nengo_gui to figure out which model we should be attaching the hook to (since we might have multiple pages open looking at different models).  This works great.  However, if we run outside of the ExecutionEnvironment (which happens when embedding inside Jupyter notebooks), then the hooks are attached globally.  This is fine for multiple open notebooks (since those are run in different kernels), but if there are multiple cells in the notebook that use nengo_gui, or if you re-execute a cell that uses hooks, then you will now have the same hook running multiple times.

In this PR, I do the decorator registration approach, but you also have to specify the model (i.e. the `nengo.Network` instance) that you're attaching the hook to.  This means we don't have to do anything with the ExecutionEnvironment, and it works fine and consistently in both normal nengo_gui and in Jupyter notebooks.

The syntax for this hook system is as follows:

```
model = nengo.Network()

@nengo_gui.hooks.on_start(model)
def on_start(sim):
    print('Start')
    
@nengo_gui.hooks.on_close(model)
def on_close(sim):
    print('Close')
    
@nengo_gui.hooks.on_pause(model)
def on_pause(sim):
    print('Pause')
    
@nengo_gui.hooks.on_continue(model)
def on_continue(sim):
    print('Continue')
    
@nengo_gui.hooks.on_step(model)
def on_step(sim):
    print('Step')
```