### PR TITLE
Fix height of filemenu.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Release History
 0.4.1 (unreleased)
 ==================
 
+- Bugfix: File menu no longer has an incorrect height
 - Bugfix: SPA plots for nengo_spa are now created correctly
 
 0.4.0 (June 1, 2018)

--- a/nengo_gui/static/side_menu.css
+++ b/nengo_gui/static/side_menu.css
@@ -1,10 +1,10 @@
 
 .sidenav-container {
-    height: calc(100% - 120px);
+    height: 100%;
     width: 250px;
-    position: fixed;
+    position: absolute;
     z-index: 9999;
-    top: 34px;
+    top: 0;
     left: 0;
     background-color: #eee;
     overflow-x: hidden;
@@ -28,8 +28,8 @@
 }
 
 .sidenav-container #Menu_content{
-  position: absolute;
   width: 2000px;
+  height: 100%;
   margin: 0px;
   padding: 0px;
 }
@@ -98,7 +98,7 @@
     top: 0;
     left: 0;
     width: 250px;
-    height: 0px;
+    height: 100%;
     border-bottom-right-radius: 4px;
     color: inherit;
     padding: 0.2em;

--- a/nengo_gui/static/side_menu.js
+++ b/nengo_gui/static/side_menu.js
@@ -59,14 +59,6 @@ Nengo.SideMenu = function() {
 
             });
     }
-
-    $(window).on('resize', function() {self.on_resize();});
-    self.on_resize();
-};
-
-Nengo.SideMenu.prototype.on_resize = function() {
-    var h = $('.sidenav-container').height();
-    $('#filebrowser').height(h);
 };
 
 

--- a/nengo_gui/templates/page.html
+++ b/nengo_gui/templates/page.html
@@ -24,59 +24,6 @@
 
     <body id="body" onload="onload();">
         <!-- Contains all sidenav html -->
-        <div class="sidenav-container">
-
-            <!-- holds all the sidenav content -->
-            <div id="Menu_content">
-
-                <!-- tab-content hold the content for their correpsonding sidenav tab -->
-                <!-- The first tab-content holds the content for the first menu tab -->
-                <div class="tab-content">
-                    <div id="filebrowser"></div>
-                </div>
-
-                <div class="tab-content">
-                    <div class="accordion-container" id="accordion-container1">
-                        <!-- side-menu-item creates a menu item for non accordion content -->
-                        <div id='Config_button' class="side-menu-item">
-                            <p class="title">Configure Settings</p>
-                            <p class="icon">
-                                <span class='glyphicon glyphicon-cog'></span>
-                            </p>
-                        </div>
-
-                        <div class="accordion-toggle">
-                            <p class="title">Download</p>
-                            <p class="icon">
-                                <span class="glyphicon glyphicon-chevron-down"></span>
-                            </p>
-                        </div>
-                        <div class="accordion-content">
-                            <div class="side-menu-item indent" id="Download_button">
-                                <p class="title">Download Simulation Data</p>
-                                <p class="icon">
-                                    <span class="glyphicon glyphicon-signal"></span>
-                                </p>
-                            </div>
-                            <div class="side-menu-item indent" id='Pdf_button'>
-                                <p class="title">Export layout as SVG</p>
-                                <p class="icon">
-                                    <span class="glyphicon glyphicon-picture"></span>
-                                </p>
-                            </div>
-                        </div>
-
-                        <div id='Minimap_button' class="side-menu-item">
-                            <p class="title">Minimap</p>
-                            <p class="icon">
-                                <span class='glyphicon glyphicon-credit-card'></span>
-                            </p>
-                        </div>
-
-                    </div>
-                </div>
-            </div>
-        </div>
         <div id="top_toolbar_div">
             <ul id='toolbar_object' class="nav nav-pills">
                 <li id='Open_file_button' role="presentation">
@@ -121,6 +68,59 @@
             </ul>
         </div>
         <div id="vmiddle">
+          <div class="sidenav-container">
+
+              <!-- holds all the sidenav content -->
+              <div id="Menu_content">
+
+                  <!-- tab-content hold the content for their correpsonding sidenav tab -->
+                  <!-- The first tab-content holds the content for the first menu tab -->
+                  <div class="tab-content">
+                      <div id="filebrowser"></div>
+                  </div>
+
+                  <div class="tab-content">
+                      <div class="accordion-container" id="accordion-container1">
+                          <!-- side-menu-item creates a menu item for non accordion content -->
+                          <div id='Config_button' class="side-menu-item">
+                              <p class="title">Configure Settings</p>
+                              <p class="icon">
+                                  <span class='glyphicon glyphicon-cog'></span>
+                              </p>
+                          </div>
+
+                          <div class="accordion-toggle">
+                              <p class="title">Download</p>
+                              <p class="icon">
+                                  <span class="glyphicon glyphicon-chevron-down"></span>
+                              </p>
+                          </div>
+                          <div class="accordion-content">
+                              <div class="side-menu-item indent" id="Download_button">
+                                  <p class="title">Download Simulation Data</p>
+                                  <p class="icon">
+                                      <span class="glyphicon glyphicon-signal"></span>
+                                  </p>
+                              </div>
+                              <div class="side-menu-item indent" id='Pdf_button'>
+                                  <p class="title">Export layout as SVG</p>
+                                  <p class="icon">
+                                      <span class="glyphicon glyphicon-picture"></span>
+                                  </p>
+                              </div>
+                          </div>
+
+                          <div id='Minimap_button' class="side-menu-item">
+                              <p class="title">Minimap</p>
+                              <p class="icon">
+                                  <span class='glyphicon glyphicon-credit-card'></span>
+                              </p>
+                          </div>
+
+                      </div>
+                  </div>
+              </div>
+          </div>
           <div id="main" class="droppable"></div>
           <div id="rightpane"></div>
         </div>


### PR DESCRIPTION
Fixes #966.

Moved the filemenu into the `vmiddle` container to be able to inherit its height instead of doing height calculations with magic numbers. Also allowed to remove some `on_resize` JS code.