### PR TITLE
Prevent failure for SPA Transcode plots.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Release History
 0.4.2 (unreleased)
 ==================
 
+- Bugfix: Cloud plots for nengo_spa.Transcode plots no longer fail
 
 
 0.4.1 (June 5, 2018)

--- a/nengo_gui/components/pointer.py
+++ b/nengo_gui/components/pointer.py
@@ -57,12 +57,15 @@ class Pointer(SpaPlot):
             if loop_in and self.target == 'default':
                 input = self.obj.inputs[self.target][0]
                 self.conn2 = nengo.Connection(self.node, input, synapse=0.01)
-            else:
+            elif output.size_in > 0:
                 self.conn2 = nengo.Connection(self.node, output, synapse=0.01)
+            else:
+                self.conn2 = None
 
     def remove_nengo_objects(self, page):
         page.model.connections.remove(self.conn1)
-        page.model.connections.remove(self.conn2)
+        if self.conn2 is not None:
+            page.model.connections.remove(self.conn2)
         page.model.nodes.remove(self.node)
 
     def gather_data(self, t, x):


### PR DESCRIPTION
Fixes #970.

This is only a hotfix preventing a complete crash of the GUI. The
functionality to override the output value for Transcode modules is
still not working with this even though the context menu suggests
otherwise. In the future, values should be overwritten in the same
way as we do for nodes.