### PR TITLE
Fail gracefully if binding server to address fails

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Release History
 0.4.3 (unreleased)
 ==================
 
+- Bugfix: Fail gracefully when binding server
 
 0.4.2 (June 8, 2018)
 ====================

--- a/nengo_gui/server.py
+++ b/nengo_gui/server.py
@@ -148,6 +148,7 @@ class DualStackHttpServer(object):
             if self.address_family is socket.AF_INET6:
                 self.socket.setsockopt(
                     IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+            self.name = None
 
         def bind(self):
             self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)

--- a/nengo_gui/server.py
+++ b/nengo_gui/server.py
@@ -225,6 +225,8 @@ class DualStackHttpServer(object):
                     raise
 
         self.bindings = [b for b in self.bindings if b.bound]
+        if not self.bindings:
+            raise RuntimeError("Could not bind to any address.")
 
     def server_activate(self):
         for b in self.bindings:


### PR DESCRIPTION
This should fix #974.

If `'localhost'` is given as the server address, we retrieve the associated network addresses to listen on with `getaddrinfo`. For me this returns the IPv4 address `127.0.0.1` and IPv6 address `::1`. But on at least one system (see #974) the link-local address `fe80::1%lo0` was returned to. I'm not sure whether one cannot bind to that address in general (because the error is `EADDRNOTAVAIL`) or whether it ends up trying to bind the same adress again (because we already bound `::1`, but the error is not `EADDRINUSE`). There might be a way to filter these addresses, but my knowledge of IPv6 isn't sufficient to say for sure or come up with an implementation.

Thus, I decided to just catch the `EADDRNOTAVAIL` and `EADDRINUSE` errors and convert them to warnings. This keeps the GUI running if we fail to bind to one address. The only potential problem could be that we bind to the wrong address first and this prevents binding to the correct address. But this seems unlikely; I'd assume that if binding to one address prevents binding to another address, both of these addresses can be used interchangeably.