### PR TITLE
Acquire lock when using Jedi

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Release History
 0.4.3 (unreleased)
 ==================
 
+- Bugfix: thread-safety for jedi autocompletion
 - Bugfix: Handle authentication when connecting to multiple servers
 - Bugfix: Fail gracefully when binding server
 

--- a/nengo_gui/completion.py
+++ b/nengo_gui/completion.py
@@ -7,7 +7,7 @@ except ImportError:
         "Install the jedi module to get autocompletion in Nengo GUI.")
 
     class Script(object):
-        def __init__(*args, **kwargs):
+        def __init__(self, *args, **kwargs):
             pass
 
         def completions(self):

--- a/nengo_gui/completion.py
+++ b/nengo_gui/completion.py
@@ -1,3 +1,4 @@
+import threading
 import warnings
 
 try:
@@ -14,6 +15,9 @@ except ImportError:
             return []
 
 
+_jedi_lock = threading.Lock()
+
 def get_completions(code, line, column, path=None):
-    script = Script(code, line, column, path=path)
-    return script.completions()
+    with _jedi_lock:
+        script = Script(code, line, column, path=path)
+        return script.completions()

--- a/nengo_gui/guibackend.py
+++ b/nengo_gui/guibackend.py
@@ -2,7 +2,6 @@
 
 from __future__ import print_function
 
-import hashlib
 import json
 import logging
 import mimetypes


### PR DESCRIPTION
This should ensure thread safety, but might not give the best
performance. It might be possible to skip processing of some
requests if too many arrive in a short interval instead of processing
all of them with a delay once the lock becomes available for each
request.

Addresses #975.