### PR TITLE
Fix shared session ID across ports.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Release History
 0.4.3 (unreleased)
 ==================
 
+- Bugfix: Handle authentication when connecting to multiple servers
 - Bugfix: Fail gracefully when binding server
 
 0.4.2 (June 8, 2018)

--- a/nengo_gui/guibackend.py
+++ b/nengo_gui/guibackend.py
@@ -310,7 +310,8 @@ class GuiRequestHandler(server.HttpWsRequestHandler):
             peer_name = None
 
         try:
-            session_id = self.cookie['_session_id'].value
+            session_id = self.cookie[
+                '_sid_' + str(self.server.server_port)].value
             session = self.server.sessions[session_id]
             if session.peer_name != peer_name:
                 logger.warning(
@@ -323,7 +324,7 @@ class GuiRequestHandler(server.HttpWsRequestHandler):
 
     def persist_session(self, session):
         session_id = self.server.sessions.add_session(self.request, session)
-        self.cookie['_session_id'] = session_id
+        self.cookie['_sid_' + str(self.server.server_port)] = session_id
 
     def log_message(self, format, *args):
         logger.info(format, *args)


### PR DESCRIPTION
Fixes #979.

Cookies do not differentiate between ports and are sent to all servers
on the same domain independent of the port. Thus, we append the port
to the cookie name to tell them apart.