### PR TITLE
Discover backends from entry points.

### DIFF
--- a/nengo_gui/components/slider.py
+++ b/nengo_gui/components/slider.py
@@ -98,7 +98,7 @@ class Slider(Component):
         if Process.__module__ == "nengo_gui.components.slider":
             self.node.output = self.override_output.make_step(
                 shape_in=None, shape_out=self.node.size_out, dt=None, rng=None)
-        elif page.settings.backend == 'nengo_spinnaker':
+        elif page.settings.backend == 'spinnaker':
             # TODO: this should happen for any backend that does not support
             #  Processes
             self.node.output = self.override_output.make_step(

--- a/nengo_gui/exec_env.py
+++ b/nengo_gui/exec_env.py
@@ -1,6 +1,7 @@
 import contextlib
 import importlib
 import os
+from pkg_resources import iter_entry_points
 import threading
 import traceback
 import sys
@@ -8,14 +9,21 @@ from nengo.utils.compat import StringIO
 
 
 # list of Simulators to check for
-known_modules = ['nengo', 'nengo_ocl', 'nengo_distilled',
-                 'nengo_dl', 'nengo_mpi',
-                 'nengo_brainstorm', 'nengo_spinnaker']
+known_modules = ['reference', 'ocl', 'distilled', 'dl', 'mpi', 'brainstorm',
+                 'spinnaker']
 
 
 def discover_backends():
-    found_modules = {}
+    found_modules = {
+        ep.name: ep.load for ep in iter_entry_points(group='nengo.backends')}
+
     for name in known_modules:
+        if name == 'reference':
+            prefixed_name = 'nengo'
+        else:
+            prefixed_name = 'nengo_' + name
+        if prefixed_name in found_modules:
+            continue
         try:
             mod = importlib.import_module(name)
         except Exception as e:
@@ -23,7 +31,7 @@ def discover_backends():
             # other errors to the user as they might help debugging broken
             # backend installations
             continue
-        found_modules[name] = mod
+        found_modules[name] = lambda: mod.Simulator
     return found_modules
 
 
@@ -107,13 +115,16 @@ class ExecutionEnvironment(object):
         sys.stdout = self.stdout
 
         if not self.allow_sim:
-            for mod in discover_backends().values():
-                self.simulators[mod] = mod.Simulator
-                mod.Simulator = make_dummy(mod.Simulator)
+            for load in discover_backends().values():
+                Simulator = load()
+                mod = importlib.import_module(Simulator.__module__)
+                name = Simulator.__name__
+                self.simulators[(mod, name)] = Simulator
+                setattr(mod, name, make_dummy(Simulator))
 
     def __exit__(self, exc_type, exc_value, traceback):
-        for mod, cls in self.simulators.items():
-            mod.Simulator = cls
+        for (mod, name), cls in self.simulators.items():
+            setattr(mod, name, cls)
         flag.executing = False
 
         sys.stdout = sys.__stdout__

--- a/nengo_gui/main.py
+++ b/nengo_gui/main.py
@@ -50,7 +50,7 @@ def main():
         '--debug', action='store_true', help='turn on debug logging')
     parser.add_argument(
         '-b', '--backend', metavar='BACKEND',
-        default='nengo', type=str, help='default backend to use')
+        default='reference', type=str, help='default backend to use')
     parser.add_argument('--browser', dest='browser', type=str,
         metavar='BROWSER', default=True,
         help=browser_help)

--- a/nengo_gui/page.py
+++ b/nengo_gui/page.py
@@ -47,7 +47,7 @@ class Page(object):
     """
 
     # Some Simulators can only have one instance running at a time
-    singleton_sims = dict(nengo_spinnaker=None)
+    singleton_sims = dict(spinnaker=None)
 
     def __init__(self, gui, filename, settings, reset_cfg=False):
         self.gui = gui
@@ -458,7 +458,8 @@ class Page(object):
                 c.add_nengo_objects(self)
 
             # determine the backend to use
-            backend = importlib.import_module(self.settings.backend)
+            Simulator = nengo_gui.exec_env.discover_backends()[
+                self.settings.backend]()
             # if only one Simulator is allowed at a time, finish the old one
             old_sim = Page.singleton_sims.get(self.settings.backend, None)
             if old_sim is not None and old_sim is not self:
@@ -468,15 +469,15 @@ class Page(object):
             exec_env = nengo_gui.exec_env.ExecutionEnvironment(self.filename,
                                                                allow_sim=True)
             handles_progress = ('progress_bar' in 
-                          inspect.getargspec(backend.Simulator.__init__).args)
+                          inspect.getargspec(Simulator.__init__).args)
             # build the simulation
             try:
                 with exec_env:
                     if handles_progress:
-                        self.sim = backend.Simulator(
+                        self.sim = Simulator(
                             self.model, progress_bar=self.locals['_viz_progress'])
                     else:
-                        self.sim = backend.Simulator(self.model)
+                        self.sim = Simulator(self.model)
 
             except:
                 line = nengo_gui.exec_env.determine_line_number()


### PR DESCRIPTION
This is a more scalable solution than hardcoding all the know backends. The reference backend and Nengo OCL already provide the required entry points. Some of the other backends might not, so I left the (adopted) old code in there for now. But I would be willing to remove it to force the backends to provide the appropriate entry point.