### PR TITLE
Set minimum and maximum Nengo versions.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         ]
     },
     install_requires=[
-        "nengo>=2.8",
+        "nengo>=2.8,<3.0",
     ],
     tests_require=[
         "pytest",


### PR DESCRIPTION
Current master branch requires at least Nengo 2.8 because it is importing
```python
from nengo.utils.compat import escape
```
This PR sets Nengo requirement in the setup file accordingly.