### PR TITLE
Use class name of a network if it is more informative

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Release History
 0.4.5 (unreleased)
 ==================
 
+- Improvement: subclasses of Network use their class name as a default label
 - Bugfix: Removed duplicate response headers (fixes loading in Chrome)
 - Bugfix: Fix for running with Tornado 6
 - Bugfix: Handle recent changes to nengo.Process API (backwards-compatible)

--- a/nengo_gui/page.py
+++ b/nengo_gui/page.py
@@ -3,6 +3,7 @@ import inspect
 import json
 import logging
 import os
+import re
 import socket
 import threading
 import time
@@ -380,6 +381,9 @@ class Page(object):
             assert label is not None
             if '.' in label:
                 label = label.rsplit('.', 1)[1]
+        if (re.match(r'networks\[\d+\]', label)
+                and obj.__class__.__name__ != 'Network'):
+            label = obj.__class__.__name__
         return label
 
     def get_uid(self, obj, default_labels=None):

--- a/nengo_gui/page.py
+++ b/nengo_gui/page.py
@@ -380,8 +380,6 @@ class Page(object):
             assert label is not None
             if '.' in label:
                 label = label.rsplit('.', 1)[1]
-        if label is None:
-            label = repr(obj)
         return label
 
     def get_uid(self, obj, default_labels=None):


### PR DESCRIPTION
This implements my proposal from #1000. I think this is an improvement and would enable Nengo SPA to **not** set the label for networks and give better names to SPA objects when no explicit label is given.