### PR TITLE
Fix for connection line markers in recent nengo versions

### DIFF
--- a/nengo_gui/components/netgraph.py
+++ b/nengo_gui/components/netgraph.py
@@ -610,9 +610,10 @@ class NetGraph(Component):
             trafo = conn.transform
             if hasattr(trafo, 'init'):   # check for DenseTransform
                 trafo = trafo.init
-            if trafo.size > 0 and (np.all(trafo <= 0.0) and
-                    not np.all(np.isclose(trafo, 0.0))):
-                return "inhibitory"
+            if hasattr(trafo, 'size'):
+                if trafo.size > 0 and (np.all(trafo <= 0.0) and
+                        not np.all(np.isclose(trafo, 0.0))):
+                    return "inhibitory"
         return "normal"
 
     def get_connection_hierarchy(self, conn, default_labels=None):

--- a/nengo_gui/components/netgraph.py
+++ b/nengo_gui/components/netgraph.py
@@ -608,6 +608,8 @@ class NetGraph(Component):
             return "modulatory"
         if isinstance(conn.post_obj, nengo.ensemble.Neurons):
             trafo = conn.transform
+            if hasattr(trafo, 'init'):   # check for DenseTransform
+                trafo = trafo.init
             if trafo.size > 0 and (np.all(trafo <= 0.0) and
                     not np.all(np.isclose(trafo, 0.0))):
                 return "inhibitory"


### PR DESCRIPTION
When running with the master branch of Nengo, the GUI crashes when it tries to display connections that got to `post.neurons`.  For example:

```python
import nengo

model = nengo.Network()
with model:
    a = nengo.Ensemble(n_neurons=100, dimensions=1)
    b = nengo.Ensemble(n_neurons=100, dimensions=1)
    
    nengo.Connection(a.neurons, b.neurons)
```

This is because the gui is checking the Connection.transform object, which it expects to be either a scalar or a matrix, rather than the new Transform object.

Here is a quick fix for the common use case.  In general, we might want to also check for other types of Transforms and display them in different ways.  Note that I made this fix be backward compatible with older versions of nengo, but not in a particularly good way.