### PR TITLE
Reset pan and zoom on autolayout

### DIFF
--- a/nengo_gui/static/components/netgraph.js
+++ b/nengo_gui/static/components/netgraph.js
@@ -442,6 +442,20 @@ Nengo.NetGraph.prototype.on_message = function(event) {
                 break;
             }
         }
+    } else if (data.type === 'feedforward_layout_done') {
+        // Preserve the location of the non-netgraph components by applying
+        // the inverse transformation of the below pan/zoom reset
+        const x = viewport.x, y = viewport.y, scale = viewport.scale;
+        for (let c of Nengo.Component.components) {
+            c.w = c.w * scale;
+            c.h = c.h * scale;
+            c.x = (c.x + x) * scale;
+            c.y = (c.y + y) * scale;
+        }
+
+        // Reset the scale and offset to the initial value
+        this.scale = 1.0;
+        this.set_offset(0.0, 0.0);
     } else {
         console.log('invalid message');
         console.log(data);

--- a/nengo_gui/user_action.py
+++ b/nengo_gui/user_action.py
@@ -263,12 +263,8 @@ class FeedforwardLayout(Action):
 
         if self.uid is None:
             self.network = self.net_graph.page.model
-            self.scale = self.net_graph.page.config[self.network].size[0]
-            self.x, self.y = self.net_graph.page.config[self.network].pos
         else:
             self.network = self.obj
-            self.scale = 1.0
-            self.x, self.y = 0, 0
 
         self.pos = self.net_graph.layout.make_layout(self.network)
         # record the current positions and sizes of everything in the network
@@ -279,15 +275,15 @@ class FeedforwardLayout(Action):
     def act_feedforward_layout(self):
         for obj, layout in iteritems(self.pos):
             obj_cfg = self.net_graph.page.config[obj]
-            obj_cfg.pos = (layout['y'] / self.scale - self.x,
-                           layout['x'] / self.scale - self.y)
-            obj_cfg.size = (layout['h'] / 2 / self.scale,
-                            layout['w'] / 2 / self.scale)
+            obj_cfg.pos = (layout['y'], layout['x'])
+            obj_cfg.size = (layout['h'] / 2, layout['w'] / 2)
 
             obj_uid = self.net_graph.page.get_uid(obj)
 
             self.send('pos_size',
                       uid=obj_uid, pos=obj_cfg.pos, size=obj_cfg.size)
+
+        self.send('feedforward_layout_done')
 
         self.net_graph.page.config[self.network].has_layout = True
         self.net_graph.modified_config()


### PR DESCRIPTION
Previously, when applying an autolayout, the object coordinates were
rescaled such that they fit the current viewport taking pan and zoom
into account.

Unfortunately, this causes (a) numerical instability due to exponentially
exploding/imploding coordinates, (b) issues with scale-dependent objects
such as the multi-connection arcs I'm currently implementing.

This PR resets pan and zoom instead of rescaling the coordinates
in a new "feedforward_layout_done" message handler. Since this would
also change the coordinates of the non-netgraph components, the
transformation inverse to the pan/zoom reset is applied to these
components.