### PR TITLE
Fix `connection_kind` in Nengo 3.0

### DIFF
--- a/nengo_gui/components/netgraph.py
+++ b/nengo_gui/components/netgraph.py
@@ -608,9 +608,13 @@ class NetGraph(Component):
             return "modulatory"
         if isinstance(conn.post_obj, nengo.ensemble.Neurons):
             trafo = conn.transform
-            if trafo.size > 0 and (np.all(trafo <= 0.0) and
-                    not np.all(np.isclose(trafo, 0.0))):
-                return "inhibitory"
+            if hasattr(nengo, 'transforms'): # Support for Nengo 3.0
+                trafo = trafo.sample()
+
+            if hasattr(trafo, 'size'):
+                if trafo.size > 0 and (np.all(trafo <= 0.0) and
+                        not np.all(np.isclose(trafo, 0.0))):
+                    return "inhibitory"
         return "normal"
 
     def get_connection_hierarchy(self, conn, default_labels=None):


### PR DESCRIPTION
Connection kind detection broke with Nengo 3.0 and the introduction of
multiple transformation kinds. `test_netgraph.py` exits with failures.

This patch fixes this issue in a backwards-compatible manner by checking
for the presence of Nengo 3.0 and accessing the transfomation in the
correct way.

You can reproduce this issue by running
```bash
pytest --noconftest nengo_gui/tests/test_netgraph.py
```

**Note:** this PR is similar to #1004 but is (I think) a little cleaner. 