### PR TITLE
Draw connections between the same objects as arcs

### DIFF
--- a/nengo_gui/static/components/netgraph.css
+++ b/nengo_gui/static/components/netgraph.css
@@ -24,9 +24,10 @@ g.net rect{
     cursor: move;
 }
 
-.netgraph line {
+.netgraph path.conn {
     stroke: black;
     stroke-width: 2px;
+    fill: none;
 }
 
 .netgraph g.inhibitory > .conn {
@@ -54,9 +55,10 @@ g.net rect{
     width: 100%;
 }
 
-.minimap line {
+.minimap path.conn {
     stroke: black;
     stroke-width: 1px;
+    fill: none;
 }
 
 rect.view{


### PR DESCRIPTION
Previously, connections between the same objects were drawn on top of each
other. This patch draws connections between the same objects as arcs of
different radii, making it possible to distinguish them visually.

This is of primary interest when having separate excitatory/inhibitory connections.

![multi_arcs_1](https://user-images.githubusercontent.com/1783545/58756941-aaca6b80-84cf-11e9-87ff-144771739628.png)

Note that connections from/to networks are still drawn as a single line. This is controlled by the `has_arcs` variable in `Connection.redraw()`.

![multi_arcs_2](https://user-images.githubusercontent.com/1783545/58756967-14e31080-84d0-11e9-8f7a-66a482a6ba16.png)

Here is the code I used for testing:
```py
import nengo
import numpy as np

model = nengo.Network()
with model:
    stim = nengo.Node([0])
    a = nengo.Ensemble(n_neurons=50, dimensions=1)
    b = nengo.Ensemble(n_neurons=50, dimensions=1)
    c = nengo.Ensemble(n_neurons=50, dimensions=1)

    with nengo.Network() as net1:
        d = nengo.Ensemble(n_neurons=50, dimensions=1)
        e = nengo.Ensemble(n_neurons=50, dimensions=1)
        nengo.Connection(d, e)
        nengo.Connection(d, e)
        nengo.Connection(d, e)

    with nengo.Network() as net2:
        f = nengo.Ensemble(n_neurons=50, dimensions=1)
        g = nengo.Ensemble(n_neurons=50, dimensions=1)
        nengo.Connection(f, g)
        nengo.Connection(f, g)

    nengo.Connection(stim, a)
    nengo.Connection(stim, a.neurons, transform=-np.ones((50, 1)))
    nengo.Connection(stim, b)
    nengo.Connection(stim, c)

    nengo.Connection(a, d)
    nengo.Connection(a, e)
    nengo.Connection(d, e)
    nengo.Connection(d, f)

    nengo.Connection(b, c)
    nengo.Connection(c, b.neurons, transform=-100*np.ones((50, 1)))
```