### PR TITLE
Support for nengo-bio style excitatory and inhibitory connections

### DIFF
--- a/nengo_gui/static/components/netgraph.css
+++ b/nengo_gui/static/components/netgraph.css
@@ -29,6 +29,14 @@ g.net rect{
     stroke-width: 2px;
 }
 
+.netgraph g.excitatory > .conn {
+    stroke: #3465a4;
+}
+
+.netgraph g.excitatory > .marker {
+    fill: #3465a4;
+}
+
 .netgraph g.inhibitory > .conn {
     stroke: #c00000;
 }

--- a/nengo_gui/static/components/netgraph_conn.js
+++ b/nengo_gui/static/components/netgraph_conn.js
@@ -121,6 +121,9 @@ Nengo.NetGraphConnection.prototype.create_line = function() {
                 case "inhibitory":
                     this.marker.setAttribute('d', "M 4,0 C 4,-8 -4,-8 -4,-8 V 8 c 0,0 8,0 8,-8 z");
                     break;
+                case "excitatory":
+                    this.marker.setAttribute('d', "M -3,0.5 C -3,-6.8 -5.9,-9.7 -5.9,-9.7 L 5.8,0 -5.9,9.6 c 0,0 2.9,-2.8 2.9,-10.2 z");
+                    break;
                 case "modulatory":
                     this.marker.setAttribute('d', "M 7.5,0 0,-5 -7.5,0 0,5 z");
                     break;


### PR DESCRIPTION
This PR integrates nengo-gui with the biologically plausible connection types provided by [nengo-bio](https://github.com/astoeckel/nengo-bio).

In particular, it

- adds support for the "excitatory" connection type on the client side
- reads the nengo-bio provided connection kind
- reads the nengo-bio provided pre-object metadata to remove dead connections

![nengo_bio_support1](https://user-images.githubusercontent.com/1783545/58763624-33c2c080-852b-11e9-9063-6247fa3ef1cc.png)

![nengo_bio_support2](https://user-images.githubusercontent.com/1783545/58763644-6d93c700-852b-11e9-8894-97413b9ee9bb.png)

**Note:** this PR also includes #1010. While technically independent, this PR should be merged in conjunction with #1009 and #1011.

In case you'd like to test this functionality first, I've merged all my recent PRs #1009, #1011, #1012 into the master branch of my fork of nengo gui at https://github.com/astoeckel/nengo-gui