### PR TITLE
Fix broken sliders given recent nengo.Process API change

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Release History
 0.4.5 (unreleased)
 ==================
 
+- Bugfix: Handle recent changes to nengo.Process API (backwards-compatible)
 
 0.4.4 (June 9, 2019)
 ====================

--- a/nengo_gui/components/slider.py
+++ b/nengo_gui/components/slider.py
@@ -21,13 +21,20 @@ class OverriddenOutput(Process):
         self.to_client = to_client
         self.from_client = from_client
 
-    def make_step(self, shape_in, shape_out, dt, rng):
+    def make_step(self, shape_in, shape_out, dt, rng, state=None):
         size_out = shape_out[0] if is_iterable(shape_out) else shape_out
 
         if self.base_output is None:
             f = self.passthrough
         elif isinstance(self.base_output, Process):
-            f = self.base_output.make_step(shape_in, shape_out, dt, rng)
+            try:
+                state = self.base_output.make_state(shape_in, shape_out,
+                                                    dt, rng)
+                f = self.base_output.make_step(shape_in, shape_out, dt, rng,
+                                               state=state)
+            except AttributeError:
+                # for nengo<=2.8.0
+                f = self.base_output.make_step(shape_in, shape_out, dt, rng)
         else:
             f = self.base_output
         return self.Step(size_out, f,


### PR DESCRIPTION
The current `master` version of nengo causes nengo-gui to break if you run a model and have a slider.

Here's the commit that broke things:

https://github.com/nengo/nengo/commit/e4ac75f8cc4b140b892e765226049e393b5e07bd

(it changes the Process API, and nengo-gui uses a Process to implement the sliders)

This fix is backwards-compatible and continues to work with older nengo versions.

