### PR TITLE
Fix jupyter integration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Release History
 0.4.5 (unreleased)
 ==================
 
+- Bugfix: Fix for running with Tornado 6
 - Bugfix: Handle recent changes to nengo.Process API (backwards-compatible)
 
 0.4.4 (June 9, 2019)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Release History
 0.4.5 (unreleased)
 ==================
 
+- Bugfix: Removed duplicate response headers (fixes loading in Chrome)
 - Bugfix: Fix for running with Tornado 6
 - Bugfix: Handle recent changes to nengo.Process API (backwards-compatible)
 


### PR DESCRIPTION
This fixes two problems:

* Newer Jupyter versions use Tornado 6 and the old code wasn't compatible to that Tornado version.
* Newer Chrome versions (and potentially other browser) check the content type of HTTP responses and the server extension would respond with two (potentially conflicting) Content-Type headers which might lead to resources not being loaded properly.