### PR TITLE
Handle Python 2/3 compat

### DIFF
--- a/nengo_gui/compat.py
+++ b/nengo_gui/compat.py
@@ -1,0 +1,34 @@
+from __future__ import absolute_import
+
+import collections
+import sys
+
+import numpy as np
+
+# Only test for Python 2 so that we have less changes for Python 4
+PY2 = sys.version_info[0] == 2
+
+# If something's changed from Python 2 to 3, we handle that here
+if PY2:
+    from cgi import escape as cgi_escape
+    from StringIO import StringIO
+
+    escape = lambda s, quote=True: cgi_escape(s, quote=quote)
+    iteritems = lambda d: d.iteritems()
+
+    string_types = (str, unicode)
+    int_types = (int, long)
+    range = xrange
+
+else:
+    from html import escape
+    from io import StringIO
+
+    iteritems = lambda d: iter(d.items())
+
+
+def is_iterable(obj):
+    if isinstance(obj, np.ndarray):
+        return obj.ndim > 0  # 0-d arrays give error if iterated over
+    else:
+        return isinstance(obj, collections.Iterable)

--- a/nengo_gui/components/netgraph.py
+++ b/nengo_gui/components/netgraph.py
@@ -6,9 +6,9 @@ import threading
 import numpy as np
 
 import nengo
-from nengo.utils.compat import escape
 import json
 
+from nengo_gui.compat import escape, iteritems
 from nengo_gui.components.component import Component
 from nengo_gui.components.value import Value
 from nengo_gui.components.slider import OverriddenOutput
@@ -123,7 +123,7 @@ class NetGraph(Component):
         # for Nodes, Ensembles, and Networks, this means to find the item
         # with the same uid.  For Connections, we don't really have a uid,
         # so we use the uids of the pre and post objects.
-        for uid, old_item in nengo.utils.compat.iteritems(dict(self.uids)):
+        for uid, old_item in iteritems(dict(self.uids)):
             try:
                 new_item = eval(uid, self.page.locals)
             except:

--- a/nengo_gui/components/progress.py
+++ b/nengo_gui/components/progress.py
@@ -1,18 +1,8 @@
 import json
 
-try:
-    from nengo.utils.compat import escape
-except ImportError:
-    import sys
-    PY2 = sys.version_info[0] == 2
-    if PY2:
-        from cgi import escape as cgi_escape
-        escape = lambda s, quote=True: cgi_escape(s, quote=quote)
-    else:
-        from html import escape
-
 from nengo.utils.progress import ProgressBar, timestamp2timedelta
 
+from nengo_gui.compat import escape
 from nengo_gui.components.component import Component
 
 

--- a/nengo_gui/components/slider.py
+++ b/nengo_gui/components/slider.py
@@ -9,8 +9,8 @@ except ImportError:
     class Process(object):
         pass
 
-from nengo.utils.compat import is_iterable
 
+from nengo_gui.compat import is_iterable
 from nengo_gui.components.component import Component
 
 

--- a/nengo_gui/exec_env.py
+++ b/nengo_gui/exec_env.py
@@ -4,7 +4,8 @@ import os
 import threading
 import traceback
 import sys
-from nengo.utils.compat import StringIO
+
+from nengo_gui.compat import StringIO
 
 
 # list of Simulators to check for

--- a/nengo_gui/user_action.py
+++ b/nengo_gui/user_action.py
@@ -1,7 +1,6 @@
 """Respond to an action from the user on the NetGraph"""
 
-from nengo.utils.compat import iteritems
-
+from nengo_gui.compat import iteritems
 import nengo_gui.components
 
 


### PR DESCRIPTION
Previously, we were using Nengo core's Python 2/3 compatibility module, but Nengo core has dropped Python 2 support and subsequently removed `nengo.utils.compat`. Since we have not yet dropped Python 2 support, we add a `compat.py` module to handle the things that we use in Nengo GUI.

This PR is required for supporting Nengo 3.0.0. With this PR, the GUI seems to work, though I haven't done extensive testing.