### PR TITLE
Fix bug opening browser from script

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Release History
 0.4.6 (unreleased)
 ==================
 
+- Bugfix: Failure when opening browser from script
 
 
 0.4.5 (November 19, 2019)

--- a/nengo_gui/gui.py
+++ b/nengo_gui/gui.py
@@ -190,8 +190,8 @@ class GUI(InteractiveGUI):
 
     def start(self):
         t = threading.Thread(
-            target=webbrowser.open,
-            args=str(self.server.get_url(token='one-time')))
+            target=webbrowser.open, args=(str(self.server.get_url(token="one-time")),)
+        )
         t.start()
 
         super(GUI, self).start()


### PR DESCRIPTION
In https://forum.nengo.ai/t/trouble-with-nengo-gui/1071 a user found a bug when using the `GUI` class. This fixes it.