### PR TITLE
Update examples for Nengo 3.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Release History
 0.4.6 (unreleased)
 ==================
 
+- Bugfix: Fix examples for nengo 3.0 (those examples now require nengo>=2.6)
 - Bugfix: Failure when opening browser from script
 
 

--- a/nengo_gui/examples/hbb_tutorials/chapter3/1-addition.py
+++ b/nengo_gui/examples/hbb_tutorials/chapter3/1-addition.py
@@ -4,7 +4,7 @@
 # single neurons (i.e., addition). Addition transforms two inputs into a single 
 # output which is their sum. You will construct a network that adds two inputs. 
 # The network utilizes two communication channels going into the same neural 
-# population. Addition is somewhat â€˜freeâ€™, since the incoming currents from 
+# population. Addition is somewhat ‘free’, since the incoming currents from 
 # different synaptic connections interact linearly.
 
 # This model has ensembles A and B which represent the two inputs to be added. 
@@ -33,15 +33,15 @@
 #Setup the environment
 import nengo
 from nengo.dists import Uniform
-from nengo.utils.functions import piecewise
+from nengo.processes import Piecewise
 
 #Create the network
 model = nengo.Network(label='Scalar Addition')
 
 with model:
     #Inputs to drive the activity in ensembles A and B 
-    input_A = nengo.Node(piecewise({0: -0.75, 1.25: 0.5, 2.5: 0.70, 3.75: 0}))
-    input_B = nengo.Node(piecewise({0: 0.25, 1.25: -0.5, 2.5: 0.85, 3.75: 0}))
+    input_A = nengo.Node(Piecewise({0: -0.75, 1.25: 0.5, 2.5: 0.70, 3.75: 0}))
+    input_B = nengo.Node(Piecewise({0: 0.25, 1.25: -0.5, 2.5: 0.85, 3.75: 0}))
 
     #Ensembles with 100 LIF neurons each
     # Represents the first input

--- a/nengo_gui/examples/hbb_tutorials/chapter3/3-non_linear.py
+++ b/nengo_gui/examples/hbb_tutorials/chapter3/3-non_linear.py
@@ -37,14 +37,13 @@
 
 # Setup the environment
 import nengo
-from nengo.dists import Choice
-from nengo.utils.functions import piecewise
+from nengo.processes import Piecewise
 
 model = nengo.Network(label='Nonlinear Function')
 with model:
     #Input - Piecewise step functions
-    inputX = nengo.Node(piecewise({0: -0.75, 1.25: 0.5, 2.5: -0.75, 3.75: 0}))
-    inputY= nengo.Node(piecewise({0: 1, 1.25: 0.25, 2.5: -0.25, 3.75: 0.75}))
+    inputX = nengo.Node(Piecewise({0: -0.75, 1.25: 0.5, 2.5: -0.75, 3.75: 0}))
+    inputY= nengo.Node(Piecewise({0: 1, 1.25: 0.25, 2.5: -0.25, 3.75: 0.75}))
     
     #Five ensembles containing LIF neurons
     X = nengo.Ensemble(100, dimensions=1, radius=1)     # Represents inputX

--- a/nengo_gui/examples/hbb_tutorials/chapter8/2D_decision_integrator.py
+++ b/nengo_gui/examples/hbb_tutorials/chapter8/2D_decision_integrator.py
@@ -40,11 +40,8 @@
 #    (i.e., when LIP starts following MT)
 
 #Setup the environment
-import numpy as np
 import nengo
 from nengo.processes import WhiteNoise
-from nengo.utils.functions import piecewise
-from nengo.utils.matplotlib import rasterplot
 from nengo.dists import Uniform
 
 model = nengo.Network(label='2D Decision Integrator', seed=11)


### PR DESCRIPTION
Some of the examples didn't work with Nengo 3.0 (as noticed in https://github.com/nengo/nengo-gui/issues/1023), went through all of the examples and fixed any errors that popped up.