### PR TITLE
Limit maximum Nengo version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         ]
     },
     install_requires=[
-        "nengo",
+        "nengo<=3.0.0",
     ],
     tests_require=[
         "pytest",


### PR DESCRIPTION
We're not actively maintaining this version of NengoGUI, so to avoid issues with newer versions of NengoCore, let's limit this to the last version that we know works, 3.0.0.