### PR TITLE
Use collections.abc.Iterable

### DIFF
--- a/nengo_gui/compat.py
+++ b/nengo_gui/compat.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import collections
+import collections.abc
 import sys
 
 import numpy as np
@@ -32,4 +32,4 @@ def is_iterable(obj):
     if isinstance(obj, np.ndarray):
         return obj.ndim > 0  # 0-d arrays give error if iterated over
     else:
-        return isinstance(obj, collections.Iterable)
+        return isinstance(obj, collections.abc.Iterable)


### PR DESCRIPTION
collections.Iterable was deprecated since Python 3.3, see note at the top of

https://docs.python.org/3.9/library/collections.html

Use collections.abc.Iterable instead.

Fixes #1039